### PR TITLE
Fix comment that broke rate limiting

### DIFF
--- a/setup/aws-iot-device-client.service
+++ b/setup/aws-iot-device-client.service
@@ -3,7 +3,8 @@ Description=AWS IoT Device Client
 Wants=network-online.target
 After=network.target network-online.target
 Requires=dbus.socket
-StartLimitIntervalSec=0 # disable rate limiting
+# disable rate limiting
+StartLimitIntervalSec=0
 
 [Service]
 Environment="CONF_PATH=/etc/.aws-iot-device-client/aws-iot-device-client.conf"


### PR DESCRIPTION
Comments are not allowed at end of lines, so parsing was failing and the default value was used.  Fixed by moving comment to its own line.