### PR TITLE
Start after watchdog, shut down before watchdog

### DIFF
--- a/setup/aws-iot-device-client.service
+++ b/setup/aws-iot-device-client.service
@@ -5,6 +5,7 @@ After=network.target network-online.target
 Requires=dbus.socket
 # disable rate limiting
 StartLimitIntervalSec=0
+After=binsentry-watchdog.service
 
 [Service]
 Environment="CONF_PATH=/etc/.aws-iot-device-client/aws-iot-device-client.conf"


### PR DESCRIPTION
The watchdog checks to see if this service is running, so ensure it is started after and shut down before the watchdog service. Since there is no explicit dependency I didn't add "Requires" or "Wants".